### PR TITLE
chore: scaffold monorepo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/knwn
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=minio
+S3_SECRET_KEY=minio123
+S3_BUCKET=files
+MAX_UPLOAD_BYTES=1073741824
+TIMEZONE=Asia/Kolkata

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Environment & commands
+- Use Node 20+, pnpm 9+.
+- Install: pnpm i
+- Dev: pnpm dev
+- Migrate DB: pnpm db:migrate
+- Seed: pnpm db:seed
+- Lint: pnpm lint
+- Types: pnpm typecheck
+- Test: pnpm test
+- E2E: pnpm e2e
+
+# Build & test policy
+- Before finishing any task, run: pnpm lint && pnpm typecheck && pnpm test
+- If API or UI changed, also run: pnpm e2e
+- Repo must end in a clean git state with all tests passing.
+
+# Style & conventions
+- TypeScript strict mode everywhere.
+- REST endpoints under /api/v1.
+- Use Zod for request validation.
+
+# PR/commit guidance
+- Commit directly to main in this sandbox (no branches).
+- Conventional commit style, include scope (e.g., feat(api): create tasks).
+- PR message (if created) must summarize endpoints/UI and list tests executed.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "api",
+  "version": "0.0.1",
+  "main": "src/main.ts",
+  "scripts": {
+    "dev": "ts-node-dev --respawn src/main.ts",
+    "build": "tsc",
+    "start": "node dist/main.js"
+  }
+}

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1,0 +1,157 @@
+// Prisma schema for KNwN Calendar
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum TaskType { static carousel video }
+enum VideoSubtype { shoot_based render_based basic_animated }
+enum CarouselSubtype { static animated }
+
+enum StaticStatus {
+  ideation copy_pending copy_ready design_pending design_ready approval_pending
+  feedback_received approved
+}
+
+enum AnimatedCarouselStatus {
+  ideation copy_pending copy_ready design_pending design_ready
+  animation_pending animated approval_pending feedback_received approved
+}
+
+enum VideoBasicStatus {
+  ideation copy_pending copy_ready design_pending design_ready
+  animation_pending animated approval_pending feedback_received approved
+}
+
+enum VideoRenderStatus {
+  ideation copy_pending copy_ready render_pending render_ready
+  animation_pending animated approval_pending feedback_received approved
+}
+
+enum VideoShootStatus {
+  ideation copy_script_pending copy_script_ready
+  preprod_checklist shoot_scheduled shoot_done
+  lineup_pending lineup_done
+  editing_pending video_ready approval_pending feedback_received approved
+}
+
+model TeamMember {
+  id          String           @id @default(cuid())
+  name        String
+  email       String?          @unique
+  active      Boolean          @default(true)
+  roles       TeamMemberRole[]
+  assignments TaskAssignment[]
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+}
+
+model Role {
+  id    String @id @default(cuid())
+  name  String @unique
+  users TeamMemberRole[]
+}
+
+model TeamMemberRole {
+  id           String @id @default(cuid())
+  teamMemberId String
+  roleId       String
+  teamMember   TeamMember @relation(fields: [teamMemberId], references: [id])
+  role         Role       @relation(fields: [roleId], references: [id])
+}
+
+model Client {
+  id        String   @id @default(cuid())
+  name      String   @unique
+  projects  Project[]
+  createdAt DateTime @default(now())
+}
+
+model Project {
+  id        String  @id @default(cuid())
+  clientId  String
+  client    Client @relation(fields: [clientId], references: [id])
+  name      String
+  notes     String?
+  tasks     Task[]
+  createdAt DateTime @default(now())
+}
+
+model SizePreset {
+  id       String @id @default(cuid())
+  label    String
+  width    Int?
+  height   Int?
+  platform String?
+}
+
+model Task {
+  id           String @id @default(cuid())
+  projectId    String
+  project      Project @relation(fields: [projectId], references: [id])
+
+  title        String
+  description  String?
+  taskType     TaskType
+  videoSubtype     VideoSubtype?
+  carouselSubtype  CarouselSubtype?
+
+  sizePresetId String?
+  sizePreset   SizePreset? @relation(fields: [sizePresetId], references: [id])
+
+  goLiveDate   DateTime
+  startDate    DateTime?
+  clientDate   DateTime?
+
+  referenceText String?
+  referenceUrls Json?
+
+  staticStatus            StaticStatus?
+  animatedCarouselStatus  AnimatedCarouselStatus?
+  videoBasicStatus        VideoBasicStatus?
+  videoRenderStatus       VideoRenderStatus?
+  videoShootStatus        VideoShootStatus?
+
+  clientDependency    Boolean @default(false)
+  clientDependencyNote String?
+
+  clientFeedbackGeneral String?
+
+  stepData Json?
+  feedback Json?
+
+  approvedAt DateTime?
+  approvedById String?
+
+  assignments TaskAssignment[]
+  files       TaskFile[]
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model TaskAssignment {
+  id           String @id @default(cuid())
+  taskId       String
+  teamMemberId String
+  roleId       String?
+  task         Task       @relation(fields: [taskId], references: [id])
+  member       TeamMember @relation(fields: [teamMemberId], references: [id])
+  role         Role?      @relation(fields: [roleId], references: [id])
+}
+
+model TaskFile {
+  id         String @id @default(cuid())
+  taskId     String
+  fileName   String
+  mimeType   String
+  size       Int
+  storageKey String
+  uploadedBy String?
+  createdAt  DateTime @default(now())
+  task       Task @relation(fields: [taskId], references: [id])
+}

--- a/apps/api/src/main.test.ts
+++ b/apps/api/src/main.test.ts
@@ -1,0 +1,17 @@
+import request from 'supertest';
+import app from './main';
+
+describe('tasks API', () => {
+  it('creates a task', async () => {
+    const res = await request(app)
+      .post('/api/v1/tasks')
+      .send({ title: 'Test', goLiveDate: '2024-01-01' });
+    expect(res.status).toBe(201);
+    expect(res.body.title).toBe('Test');
+  });
+
+  it('rejects invalid task', async () => {
+    const res = await request(app).post('/api/v1/tasks').send({});
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,0 +1,40 @@
+import express from 'express';
+import { z } from 'zod';
+
+const app = express();
+app.use(express.json());
+
+app.get('/api/v1/health', (_req, res) => {
+  res.json({ ok: true });
+});
+
+const taskSchema = z.object({
+  title: z.string(),
+  goLiveDate: z.string()
+});
+
+type Task = z.infer<typeof taskSchema>;
+
+const tasks: Task[] = [];
+
+app.get('/api/v1/tasks', (_req, res) => {
+  res.json(tasks);
+});
+
+app.post('/api/v1/tasks', (req, res) => {
+  const parsed = taskSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  tasks.push(parsed.data);
+  res.status(201).json(parsed.data);
+});
+
+export default app;
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`API listening on port ${port}`);
+  });
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>KNwN Calendar</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "web",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+function App() {
+  return <h1>KNwN Calendar</h1>;
+}
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,20 @@
+import pluginTs from '@typescript-eslint/eslint-plugin';
+import parserTs from '@typescript-eslint/parser';
+import eslintPluginImport from 'eslint-plugin-import';
+
+export default [
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: parserTs,
+      parserOptions: { sourceType: 'module' }
+    },
+    plugins: {
+      '@typescript-eslint': pluginTs,
+      import: eslintPluginImport
+    },
+    rules: {
+      'import/order': 'error'
+    }
+  }
+];

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:16
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: knwn
+    ports:
+      - "5432:5432"
+  minio:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+volumes:
+  minio_data:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "knwn-calendar",
+  "version": "0.0.1",
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "dev": "concurrently \"pnpm -C apps/api dev\" \"pnpm -C apps/web dev\"",
+    "lint": "eslint . --ext .ts,.tsx",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "e2e": "vitest run",
+    "db:migrate": "prisma migrate dev",
+    "db:seed": "prisma db seed"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.19",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "concurrently": "^8.2.2",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "prisma": "^5.9.0",
+    "supertest": "^6.3.3",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.2",
+    "vitest": "^1.2.2"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.9.0",
+    "express": "^4.18.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zod": "^3.22.4",
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.1.0"
+  }
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@knwn/types",
+  "version": "0.0.1",
+  "types": "src/index.ts"
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,4 @@
+export interface Task {
+  title: string;
+  goLiveDate: string;
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - apps/*
+  - packages/*

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "outDir": "dist"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": ["apps/**/*", "packages/**/*"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts']
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold pnpm monorepo with api and web workspaces
- add Express API with basic task endpoints and Prisma schema
- bootstrap React Vite frontend

## Testing
- `pnpm lint` (fails: Cannot find package '@typescript-eslint/eslint-plugin')
- `pnpm typecheck` (fails: missing type declarations)
- `pnpm test` (fails: vitest not found)
- `pnpm e2e` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_689d548373608322913165d9db387b06